### PR TITLE
fix: Update IAM permissions for load balancer controller 2.13.x

### DIFF
--- a/modules/iam-role-for-service-accounts-eks/policies.tf
+++ b/modules/iam-role-for-service-accounts-eks/policies.tf
@@ -851,6 +851,7 @@ data "aws_iam_policy_document" "load_balancer_controller" {
       "ec2:DescribeVpcs",
       "ec2:DescribeVpcPeeringConnections",
       "ec2:DescribeSubnets",
+      "ec2:DescribeRouteTables",
       "ec2:DescribeSecurityGroups",
       "ec2:DescribeInstances",
       "ec2:DescribeNetworkInterfaces",


### PR DESCRIPTION
Latest release of AWS LBC (v2.13.x) adds this permission `ec2:DescribeRouteTables`

Motivation and Context
latest IAM Policy for AWS LBC: https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/install/iam_policy.json

Breaking Changes
No.

How Has This Been Tested?
 I have updated at least one of the examples/* to demonstrate and validate my change(s)
 I have tested and validated these changes using one or more of the provided examples/* projects
 I have executed pre-commit run -a on my pull request

Closes: https://github.com/terraform-aws-modules/terraform-aws-iam/issues/568